### PR TITLE
fix: prevent chunked requests

### DIFF
--- a/adapter_fasthttp.go
+++ b/adapter_fasthttp.go
@@ -78,6 +78,7 @@ func (a *fastHttpReqAdapter) SetBodyStream(body io.ReadWriteCloser, bodySize int
 
 func (a *fastHttpReqAdapter) SetBody(body []byte) {
 	a.req.SetBody(body)
+	a.req.Header.SetContentLength(len(body))
 }
 
 func (a *fastHttpReqAdapter) Body() (bts []byte) {

--- a/adapter_native.go
+++ b/adapter_native.go
@@ -54,6 +54,7 @@ func (a *nativeReqAdapter) SetBody(payload []byte) {
 	// TODO: pool these readers
 	a.body = closableReaderWriter{ReadWriter: bytes.NewBuffer(payload)}
 	a.req.Body = a.body
+	a.req.ContentLength = int64(len(payload))
 }
 
 func (a *nativeReqAdapter) Body() []byte {


### PR DESCRIPTION
As prior to this commit, 'content-length' header was not being properly set, golang net/http client interpreted those requests to be chunked, as streaming requests can't have content length set beforehand.